### PR TITLE
fix urutan routing

### DIFF
--- a/src/ProtectedPage.js
+++ b/src/ProtectedPage.js
@@ -29,10 +29,10 @@ function ProtectedPage(props) {
     return (
         <Layout {...props}>
             <Switch>
-                <Route path="/suppliers" component={SuppliersPage} />
                 <Route exact path="/" component={DashboardPage} />
                 <Route path="/suppliers/create" component={SupplierCreatePage} />
                 <Route path="/suppliers/:supplierId" component={SupplierEditPage} />
+                <Route path="/suppliers" exact component={SuppliersPage} />
                 <Route path="/categories/create" component={CategoryCreatePage} />
                 <Route path="/categories/:categoryId" component={CategoryEditPage} />
                 <Route path="/categories" component={CategoriesPage} />


### PR DESCRIPTION
jadi, masalahnya adalah karena urutan routing yang salah.

sebelumnya, route `/suppliers` didaftarkan sebelum create dan edit route, maka tiap user mengakses url `/suppliers/create` yang tampil tetap halaman `SuppliersPage` karena itu routing pertama yang tertangkap.

```javascript
<Route path="/suppliers" component={SuppliersPage} />

<Route path="/suppliers/create" component={SupplierCreatePage} />
<Route path="/suppliers/:supplierId" component={SupplierEditPage} />
```

maksudnya, kita mendaftarkan route `/suppliers`, tapi jika user mengakses `/suppliers/create` atau `/suppliers/blablabla` akan tetap tertangkap di route tersebut, karena sifatnya _matching_.

ini bisa ditangani dengan 2 cara,

yang pertama menambahkan atribut `exact` di routing.

menjadi seperti ini:

```
<Route path="/suppliers" exact component={SuppliersPage} />
```

atau, cara yang kedua adalah dengan mengubah urutan kita mendaftarkan routingnya, seperti ini.

```
<Route path="/suppliers/create" component={SupplierCreatePage} />
<Route path="/suppliers/:supplierId" component={SupplierEditPage} />
<Route path="/suppliers" exact component={SuppliersPage} />
```